### PR TITLE
Fix for post OSC update

### DIFF
--- a/EyeTrackVRResonite/EyeTrackVR.cs
+++ b/EyeTrackVRResonite/EyeTrackVR.cs
@@ -33,7 +33,7 @@ namespace EyeTrackVRResonite
         private static readonly ModConfigurationKey<float> Beta = new("beta", "Eye Swing Multiplier Y", () => 1.0f);
 
         [AutoRegisterConfigKey]
-        private static readonly ModConfigurationKey<int> OscPort = new("osc_port", "EyeTrackVR OSC port", () => 9000);
+        private static readonly ModConfigurationKey<int> OscPort = new("osc_port", "EyeTrackVR OSC port", () => 9010);
 
         [HarmonyPatch(typeof(InputInterface), MethodType.Constructor)]
         [HarmonyPatch(new[] { typeof(Engine) })]
@@ -72,7 +72,7 @@ namespace EyeTrackVRResonite
 
             public void RegisterInputs(InputInterface inputInterface)
             {
-                _eyes = new Eyes(inputInterface, "EyeTrackVR Eye Tracking");
+                _eyes = new Eyes(inputInterface, "EyeTrackVR Eye Tracking", true);
             }
 
             public void UpdateInputs(float deltaTime)

--- a/EyeTrackVRResonite/EyeTrackVRResonite.csproj
+++ b/EyeTrackVRResonite/EyeTrackVRResonite.csproj
@@ -6,7 +6,7 @@
         <OutputType>Library</OutputType>
         <AppDesignerFolder>Properties</AppDesignerFolder>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
         <FileAlignment>512</FileAlignment>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A [ResoniteModLoader](https://github.com/resonite-modding-group/ResoniteModLoade
 1. Install [ResoniteModLoader](https://github.com/resonite-modding-group/ResoniteModLoader).
 2. Place [EyeTrackVRResonite.dll](https://github.com/Meister1593/EyeTrackVRResonite/releases) into your `rml_mods` folder. This folder should be at `C:\Program Files (x86)\Steam\steamapps\common\Resonite\rml_mods` on windows or `$HOME/.steam/steam/steamapps/common/Resonite/rml_mods` on linux for a default installation. You can create it if it's missing, or if you launch the game once with ResoniteModLoader installed it will create the folder for you.
 3. Place [OscCore.dll](https://github.com/Meister1593/EyeTrackVRResonite/releases) into your Resonite base folder, one above your 'rml_mods' folder. This folder should be at `C:\Program Files (x86)\Steam\steamapps\common\Resonite` on windows or `$HOME/.steam/steam/steamapps/common/Resonite` on linux for a default installation.
-4. Start EyeTrackVR software before running the game, otherwise it won't reconnect in-game. If using newer app, select VRCFT V1 in Settings tab.
+4. Start EyeTrackVR software before running the game, otherwise it won't reconnect in-game. If using newer app, select VRCFT V1 in Settings tab and `9010` as the port.
 5. Check if it's working by looking at eyes in the mirror.
 
 # Libraries used:


### PR DESCRIPTION
Mod stopped working because of port `9000` being taken internally, there was an update to the `Eyes` function, and RML uses dotnet 4.7.2.